### PR TITLE
Fix admin mode and wrestler custom prediction type

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,11 +25,12 @@ updates:
           - "@tailwindcss/*"
           - "tailwind-merge"
           - "tw-animate-css"
-      # Drizzle ORM + kit
+      # Drizzle ORM + kit + SQLite driver
       drizzle:
         patterns:
           - "drizzle-orm"
           - "drizzle-kit"
+          - "@libsql/*"
       # DnD Kit
       dnd-kit:
         patterns:

--- a/app/(authenticated)/events/[id]/page.tsx
+++ b/app/(authenticated)/events/[id]/page.tsx
@@ -12,6 +12,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 import { useSession } from "@/app/lib/auth-client"
+import { JoinEventDialog } from "@/app/components/events/join-event-dialog"
 import { MatchPredictionCard } from "@/app/components/predictions/match-prediction-card"
 import { CustomPredictionCard } from "@/app/components/predictions/custom-prediction-card"
 import { EventAdminControls } from "@/app/components/events/event-admin-controls"
@@ -34,7 +35,9 @@ export default function EventPredictionPage({
     matches,
     participants,
     userJoin,
+    needsJoin,
     userPredictions,
+    fetchData,
     eventCustomPredictions,
     userCustomPredictions,
     predictionStats,
@@ -281,6 +284,17 @@ export default function EventPredictionPage({
           </TabsContent>
         </Tabs>
       </div>
+
+      {needsJoin && event && (
+        <JoinEventDialog
+          event={event}
+          open={true}
+          onOpenChange={(open) => {
+            if (!open) router.push('/events')
+          }}
+          onSuccess={() => fetchData()}
+        />
+      )}
     </>
   )
 }

--- a/app/(authenticated)/events/[id]/use-event-data.ts
+++ b/app/(authenticated)/events/[id]/use-event-data.ts
@@ -21,6 +21,7 @@ interface UseEventDataReturn {
   matches: MatchWithParticipants[]
   participants: EventJoinWithUser[]
   userJoin: EventJoin | null
+  needsJoin: boolean
   userPredictions: Map<string, MatchPrediction>
   eventCustomPredictions: EventCustomPredictionWithTemplate[]
   userCustomPredictions: Map<string, UserCustomPrediction>
@@ -59,6 +60,8 @@ export function useEventData(eventId: string): UseEventDataReturn {
   const [error, setError] = useState<string | null>(null)
   const [isAnimating, setIsAnimating] = useState(false)
 
+  const needsJoin = event !== null && event.status === 'open' && userJoin === null
+
   const fetchData = useCallback(async () => {
     setIsLoading(true)
     setError(null)
@@ -75,10 +78,7 @@ export function useEventData(eventId: string): UseEventDataReturn {
         const joinStatus = await apiClient.getEventJoinStatus(eventId)
         setUserJoin(joinStatus)
       } catch {
-        if (eventData.status !== 'completed' && eventData.status !== 'pending') {
-          router.push('/events')
-          return
-        }
+        setUserJoin(null)
       }
 
       const participantsData = await apiClient.getEventParticipants(eventId)
@@ -135,7 +135,7 @@ export function useEventData(eventId: string): UseEventDataReturn {
     } finally {
       setIsLoading(false)
     }
-  }, [eventId, router])
+  }, [eventId])
 
   useEffect(() => {
     fetchData()
@@ -361,6 +361,7 @@ export function useEventData(eventId: string): UseEventDataReturn {
     matches,
     participants,
     userJoin,
+    needsJoin,
     userPredictions,
     eventCustomPredictions,
     userCustomPredictions,

--- a/app/components/events/prediction-answer.tsx
+++ b/app/components/events/prediction-answer.tsx
@@ -241,15 +241,15 @@ function WrestlerAnswerInput({
         <Button
           size="sm"
           variant="outline"
-          disabled={isSaving || localIds.length === 0}
+          disabled={isSaving}
           onClick={() => onSetAnswer({ answerWrestlerId: JSON.stringify(localIds) })}
         >
-          Set Answer
+          {localIds.length === 0 ? "Set None" : "Set Answer"}
         </Button>
         {hasAnswer && (
           <Badge variant="default" className="text-xs">
             <Check className="h-3 w-3 mr-1" />
-            {wrestlerIds.length} wrestler{wrestlerIds.length !== 1 ? "s" : ""} set
+            {wrestlerIds.length === 0 ? "None" : `${wrestlerIds.length} wrestler${wrestlerIds.length !== 1 ? "s" : ""} set`}
           </Badge>
         )}
       </div>

--- a/app/components/predictions/custom-prediction-card.tsx
+++ b/app/components/predictions/custom-prediction-card.tsx
@@ -95,16 +95,6 @@ export function CustomPredictionCard({
 
   const handleWrestlerChange = async (ids: string[]) => {
     if (isLocked) return
-    if (ids.length === 0) {
-      if (!userPrediction) return
-      setIsSaving(true)
-      try {
-        await onPredictionClear(ecp.id)
-      } finally {
-        setIsSaving(false)
-      }
-      return
-    }
     await handleChange({ predictionWrestlerId: JSON.stringify(ids) })
   }
 
@@ -255,6 +245,7 @@ function formatAnswer(type: PredictionType, value: unknown, wrestlerNames?: Map<
         try {
           const ids = JSON.parse(value)
           if (Array.isArray(ids)) {
+            if (ids.length === 0) return "None"
             return ids
               .map((id) => wrestlerNames?.get(id) ?? id)
               .join(", ")

--- a/app/lib/services/event.service.ts
+++ b/app/lib/services/event.service.ts
@@ -91,6 +91,8 @@ function evaluateCustomPrediction(
       try {
         const userIds: string[] = JSON.parse(userPrediction.predictionWrestlerId);
         const answerIds: string[] = JSON.parse(answer.answerWrestlerId);
+        // Both predicted "none" — correct
+        if (answerIds.length === 0 && userIds.length === 0) return 1;
         const answerSet = new Set(answerIds);
         return userIds.filter((id) => answerSet.has(id)).length;
       } catch {

--- a/app/lib/services/prediction.service.ts
+++ b/app/lib/services/prediction.service.ts
@@ -407,8 +407,8 @@ export const customPredictionService = {
       } catch {
         throw apiError('predictionWrestlerId must be a JSON array of wrestler IDs', 400);
       }
-      if (!Array.isArray(parsedWrestlerIds) || parsedWrestlerIds.length === 0) {
-        throw apiError('At least one wrestler must be selected', 400);
+      if (!Array.isArray(parsedWrestlerIds)) {
+        throw apiError('predictionWrestlerId must be a JSON array of wrestler IDs', 400);
       }
       for (const wrestlerId of parsedWrestlerIds) {
         await ensureForeignKey(wrestlers, wrestlerId, 'Wrestler');
@@ -586,8 +586,8 @@ export const customPredictionService = {
       } catch {
         throw apiError('predictionWrestlerId must be a JSON array of wrestler IDs', 400);
       }
-      if (!Array.isArray(wrestlerIds) || wrestlerIds.length === 0) {
-        throw apiError('At least one wrestler must be selected', 400);
+      if (!Array.isArray(wrestlerIds)) {
+        throw apiError('predictionWrestlerId must be a JSON array of wrestler IDs', 400);
       }
       for (const wrestlerId of wrestlerIds) {
         await ensureForeignKey(wrestlers, wrestlerId, 'Wrestler');


### PR DESCRIPTION
Fixes #24, Fixes #25

This PR adjusts the way custom wrestler predictions are handled, as well as allows admins to be able to join in contrarian mode if they opened the predictions.